### PR TITLE
Create separate e2e_test directory and environment for browser-based tests

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,7 +5,7 @@ config :calorie, Calorie.Repo,
   username: "postgres",
   password: "coderslab",
   database: "calorie_dev",
-  hostname: "localhost",
+  hostname: "127.0.0.1",
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 

--- a/config/e2e.exs
+++ b/config/e2e.exs
@@ -1,0 +1,14 @@
+use Mix.Config
+
+import_config "test.exs"
+
+config :calorie, CalorieWeb.Endpoint,
+  http: [port: 4002],
+  server: true
+
+config :wallaby, driver: Wallaby.Chrome
+
+config :wallaby,
+  chromedriver: [
+    headless: false
+  ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,21 +5,14 @@ config :calorie, Calorie.Repo,
   username: "postgres",
   password: "coderslab",
   database: "calorie_dev",
-  hostname: "localhost",
+  hostname: "127.0.0.1",
   pool: Ecto.Adapters.SQL.Sandbox
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :calorie, CalorieWeb.Endpoint,
-  http: [port: 4000],
-  server: true
+  http: [port: 4002],
+  server: false
 
 # Print only warnings and errors during test
 config :logger, level: :warn
-
-config :wallaby, driver: Wallaby.Chrome
-
-config :wallaby,
-  chromedriver: [
-    headless: false
-  ]

--- a/e2e_test/login_test.exs
+++ b/e2e_test/login_test.exs
@@ -11,17 +11,20 @@ defmodule E2E.LoginTest do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Calorie.Repo)
   end
 
+  defp random_name() do
+    (?A..?Z) |> Enum.shuffle() |> Enum.take(10) |> List.to_string()
+  end
+
   test "a user can register with the system" do
+    new_name = random_name()
     {:ok, session} = Wallaby.start_session()
     session
-    |> visit("http://localhost:4000/users/new")
-    |> fill_in(text_field("Name"), with: "test2")
-    |> fill_in(text_field("Username"), with: "test2")
+    |> visit("http://localhost:4002/users/new")
+    |> fill_in(text_field("Name"), with: new_name)
+    |> fill_in(text_field("Username"), with: new_name)
     |> fill_in(text_field("Password"), with: "123Pasword123")
     |> find(Query.text("Create User"), fn el -> Element.click(el) end)
 
-
-   Process.sleep(20_000)
    assert_text(session, "Listing Users")
 
   end

--- a/e2e_test/test_helper.exs
+++ b/e2e_test/test_helper.exs
@@ -1,0 +1,7 @@
+ExUnit.start()
+
+#Ecto.Adapters.SQL.Sandbox.mode(Calorie.Repo, :manual)
+{:ok, _} = Application.ensure_all_started(:wallaby)
+{:ok, _} = Application.ensure_all_started(:calorie)
+
+Application.put_env(:wallaby, :base_url, CalorieWeb.Endpoint.url)

--- a/lib/calorie_web/templates/user/new.html.eex
+++ b/lib/calorie_web/templates/user/new.html.eex
@@ -1,5 +1,5 @@
 <h1>New User</h1>
-<%= if @changeset.action do%>
+<%= if @changeset.action do %>
     <div class="alert alert-danger">
         <p>Oops, something went wrong! Please check the errors below.</p>
     </div>

--- a/mix.exs
+++ b/mix.exs
@@ -1,5 +1,6 @@
 defmodule Calorie.MixProject do
   use Mix.Project
+  @test_envs [:test, :e2e]
 
   def project do
     [
@@ -7,11 +8,11 @@ defmodule Calorie.MixProject do
       version: "0.1.0",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
+      test_paths: test_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
-      deps: deps(),
-      preferred_cli_env: [e2e: :test]
+      deps: deps()
     ]
   end
 
@@ -26,8 +27,13 @@ defmodule Calorie.MixProject do
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(env) when env in @test_envs do
+    ["lib", "test/support", "e2e_test/support"]
+  end
   defp elixirc_paths(_), do: ["lib"]
+
+  defp test_paths(:e2e), do: ["e2e_test"]
+  defp test_paths(_), do: ["test"]
 
   # Specifies your project dependencies.
   #
@@ -45,7 +51,7 @@ defmodule Calorie.MixProject do
       {:jason, "~> 1.0"},
       {:plug_cowboy, "~> 2.0"},
       {:pbkdf2_elixir, "~> 1.0"},
-      {:wallaby, "~> 0.28.0", [runtime: false, only: :test]}
+      {:wallaby, "~> 0.28.0", [runtime: false, only: @test_envs ]}
     ]
   end
 
@@ -60,8 +66,6 @@ defmodule Calorie.MixProject do
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate", "test"],
-      e2e: ["ecto.create --quiet", "ecto.migrate", "phx.server", "test test/e2e"]
-
     ]
   end
 end

--- a/start_db_docker.sh
+++ b/start_db_docker.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-sudo docker run --rm --name some-postgres -p5432:5432 -e POSTGRES_PASSWORD=coderslab -e POSTGRES_DB=calorie_dev postgres:13-alpine
+sudo docker run --rm --net host --name some-postgres -p5432:5432 -e POSTGRES_PASSWORD=coderslab -e POSTGRES_DB=calorie_dev postgres:13-alpine


### PR DESCRIPTION
I leaned on this blog post https://spin.atomicobject.com/2018/10/22/elixir-test-multiple-environments/

To run e2e tests, you need:

```
MIX_ENV=e2e mix test
```

To run the other tests (these are NOT fixed)

```
mix test
```
